### PR TITLE
Workaround for windows CR/LF issue

### DIFF
--- a/jwt.sh
+++ b/jwt.sh
@@ -6,6 +6,9 @@ fi
 
 keytool -v -importkeystore -srckeystore $1 -destkeystore privateKey.p12 -deststoretype PKCS12
 
+echo Press any key to continue...
+read _
+
 openssl pkcs12 -in privateKey.p12 -nocerts -nodes -out private_key
 
 jwt1=`echo -n '{"alg":"RS256","typ":"JWT"}' | openssl base64 -e`


### PR DESCRIPTION
There's extra carriage return from 'keytool -v -importkeystore -srckeystore $1 -destkeystore privateKey.p12 -deststoretype PKCS12' that's getting passed on to the next command -- probably windows CR/LF issue -- & it doesn't wait to get the import password for 'openssl pkcs12 -in privateKey.p12 -nocerts -nodes -out private_key' Its not an elegant solution, But this will request a redundant key entry for non-windows user @kedardoshi @vybs @ShashankHarinath 